### PR TITLE
README: Remove broken image embeds.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@ Hello!
 
 You have stumbled upon a repository which contains files for the Nixie Tap device.
 
-![Blinking nixie](https://github.com/mladendinic/nixietap/blob/master/hardware/pics/nixie-tap.gif)
-
 What is a Nixie Tap? It's an ESP8266-based Nixie display in a [nice enclosure](https://github.com/mladendinic/nixietap/blob/master/hardware/pics/IMG_7451.JPG). 
 By default, it's an internet-synchronized clock, but it could be whatever you desire: IFTTT button, cryptocurrency price ticker, temperature alarm...
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@ Hello!
 
 You have stumbled upon a repository which contains files for the Nixie Tap device.
 
-What is a Nixie Tap? It's an ESP8266-based Nixie display in a [nice enclosure](https://github.com/mladendinic/nixietap/blob/master/hardware/pics/IMG_7451.JPG). 
+What is a Nixie Tap? It's an ESP8266-based Nixie display in a nice enclosure.
+
 By default, it's an internet-synchronized clock, but it could be whatever you desire: IFTTT button, cryptocurrency price ticker, temperature alarm...
 
 To build the latest hardware, use the files from the hardware folder, buy the parts and PCBs, and fire up the soldering iron.


### PR DESCRIPTION
The `hardware/pics/nixie-tap.gif` and `IMG_7451.JPG` images prev. referenced by the README were removed in 67cb834 leading to broken image embeds in the HTML rendering of the Github README.

There are two new photos in `hardware/photos/` but they are both large (~3 to ~5mb) and neither show off the hardware enclosure and so didn't seem like appropriate replacements.

_P.s. thanks for a great project! I received my hardware today and I'm excited to start playing :heart:_