### PR TITLE
firmware: fix time anim. in 12hr mode.

### DIFF
--- a/firmware/lib/nixie/nixie.cpp
+++ b/firmware/lib/nixie/nixie.cpp
@@ -94,7 +94,7 @@ void Nixie::writeLowLevel(uint8_t digit1, uint8_t digit2, uint8_t digit3, uint8_
  * With this function, time is displayed on a nixie tubes. *
  *                                                         */
 void Nixie::writeTime(time_t local, bool dot_state, bool timeFormat) {   
-	antiPoison(local);
+	antiPoison(local, timeFormat);
     if(timeFormat) {
         write(hour(local)/10, hour(local)%10, minute(local)/10, minute(local)%10, dot_state*0b1000);
     } else {
@@ -202,7 +202,7 @@ void Nixie::writeNumber(String newNumber, unsigned int movingSpeed) {
     if(k >= (numberSize - 4)) k = 0;
 }
 
-void Nixie::antiPoison(time_t local) {
+void Nixie::antiPoison(time_t local, bool timeFormat) {
 
 	uint8_t stopH1=0, stopH0=0, stopM1=0, stopM0=0;
 	uint8_t H1=0, H0=0, M1=0, M0=0;
@@ -210,8 +210,14 @@ void Nixie::antiPoison(time_t local) {
 	uint8_t indexH1=0, indexH0=0, indexM1=0, indexM0=0;
 	stopM1 = minute(local)/10;
 	stopM0 = minute(local)%10;
-	stopH1 = hour(local)/10;
-	stopH0 = hour(local)%10;
+
+	if (timeFormat) {
+		stopH1 = hour(local)/10;
+		stopH0 = hour(local)%10;
+	} else {
+		stopH1 = hourFormat12(local)/10;
+		stopH0 = hourFormat12(local)%10;
+	}
 
 	for(uint8_t i=0; i<10; i++) if(orderedDigits[i] == stopM1) indexM1 = i;
 	for(uint8_t i=0; i<10; i++) if(orderedDigits[i] == stopM0) indexM0 = i;

--- a/firmware/lib/nixie/nixie.h
+++ b/firmware/lib/nixie/nixie.h
@@ -51,7 +51,7 @@ public:
     void writeTime(time_t local, bool dot_state, bool timeFormat);
     void writeDate(time_t local, bool dot_state);
     uint8_t checkDate(uint16_t y, uint8_t m, uint8_t d, uint8_t h, uint8_t mm);
-	void antiPoison(time_t local);
+	void antiPoison(time_t local, bool timeFormat);
 	void setAnimation(bool animate);
 private:
     void writeLowLevel(uint8_t digit1, uint8_t digit2, uint8_t digit3, uint8_t digit4, uint8_t dots);


### PR DESCRIPTION
The `Nixie::antiPoison` function used by the firmware to animate the time change in `Nixie::writeTime` needs to respect the `bool timeFormat` parameter passed to `writeTime` when calculating `stopH0` and `stopH1`. Otherwise the animation temporarily shows 24hr time before reverting to the 12hr time the user configured.

You can see this happening in the following gif showing the Nixie Tap configured in 12hr mode. The time rolls over from 01:12 to 01:13 but during the animation the time 13:13 is shown briefly.

![12hr anim bugged](https://user-images.githubusercontent.com/292650/67638971-defc5980-f8c0-11e9-82ca-d8a54ae74859.gif)

After flashing a firmware with the fix in this branch the visual glitch during time rollover is gone. Now when the Nixie Tap is configured in 12hr mode the time switches from 01:15 to 01:16 without showing 13:16.

![12hr anim fixed](https://user-images.githubusercontent.com/292650/67639016-44e8e100-f8c1-11e9-977d-99172f99bdce.gif)

